### PR TITLE
Adding matlab client, referencing issue #239

### DIFF
--- a/binding-matlab/example_agent.m
+++ b/binding-matlab/example_agent.m
@@ -1,0 +1,47 @@
+%% Example using matlab gym_http_client interface
+% Example:
+% 1) Server: python gym_http_server.py
+% 2) Client: matlab -nojvm -nodisplay -nosplash -r "run example_agent.m"
+fprintf('Testing Matlab client\n');
+
+%% Setup client
+base = 'http://127.0.0.1:5000';
+client = gym_http_client(base);
+
+%% Set up enviroment
+env_id = 'CartPole-v0';
+instance_id = client.env_create(env_id);
+
+%% Run random experiment with monitor
+outdir = 'tmp/random-agent-results';
+client.env_monitor_start(instance_id, outdir, true);
+render = false;
+
+episode_count = 100;
+max_steps = 200;
+reward = 0;
+done = false;
+
+for i = 1:episode_count
+   obs = client.env_reset(instance_id);
+   for j=1:max_steps
+       action = rand();
+       [ob, reward, done, info] = ...
+           client.env_step(instance_id, action, render);
+       if done
+          break; 
+       end
+   end
+end
+
+%% Dump result info to disk
+client.env_monitor_close(instance_id);
+
+%% Upload to the scoreboard.
+% This expects the 'OPENAI_GYM_API_KEY' enviroment variable to be set on
+% the client side.
+client.upload(outdir);
+
+%% Close server
+%client.shutdown_server();
+fprintf('Matlab client test ended\n');

--- a/binding-matlab/gym_http_client.m
+++ b/binding-matlab/gym_http_client.m
@@ -1,0 +1,136 @@
+classdef gym_http_client < handle
+    % Matlab Http client for OpenAI gym    
+    
+    properties
+        remote_base        
+    end
+    
+    methods (Access = 'private')
+        % Parse a JSON response, and return a (struct) on resp_data
+        % For more information about using JSON in matlab refer to:
+        % http://mathworks.com/help/matlab/ref/webread.html
+        % http://mathworks.com/help/matlab/ref/webwrite.html
+        function [resp_data] = get_request(obj, route)            
+            resp_data.observation = '';
+        end
+        
+        % Encode a JSON message with data described on "req_data", and
+        % return a response (struct) on resp_data
+        function [resp_data] = post_request(obj, route, req_data)            
+            url = [obj.remote_base, route];            
+            options = weboptions('MediaType','application/json');
+            resp_data = webwrite(url,req_data,options);
+        end        
+    end
+    
+    methods (Access = 'public')
+        % Constructor
+        function [objInstance] = gym_http_client(remote_base)
+            objInstance.remote_base = remote_base;        
+        end
+        
+        function [resp_data] = env_create(obj, env_id)
+            route = '/v1/envs/';
+            req_data = struct('env_id',env_id);
+            resp_data = obj.post_request(route, req_data);
+            resp_data = resp_data.instance_id;
+        end
+        
+        function [resp_data] = env_list_all(obj)
+            route = '/v1/envs/';
+            resp_data = obj.get_request(obj, route);
+            resp_data = resp_data.all_envs;
+        end
+        
+        function [resp_data] = env_reset(obj, instance_id)
+            route = ['/v1/envs/', instance_id, '/reset/'];            
+            resp_data = obj.post_request(route, []);
+            resp_data = resp_data.observation;
+        end
+        
+        function [obs, reward, done, info] = env_step(obj, ...
+                instance_id, action, render)            
+            route = ['/v1/envs/', instance_id, '/step/'];
+            req_data = struct('action',action,'render',render);
+            resp_data = obj.post_request(route, req_data);
+            obs = resp_data.observation;
+            reward = resp_data.reward;
+            done = resp_data.done;
+            info = resp_data.info;
+        end
+        
+        function [resp_data] = env_action_space_info(obj, instance_id)
+            route = ['/v1/envs/', instance_id, '/action_space/'];            
+            resp_data = obj.get_request(route);
+            resp_data = resp_data.observation;
+        end
+        
+        function [resp_data] = env_observation_space_info(obj, instance_id)
+            route = ['/v1/envs/', instance_id, '/observation_space/'];            
+            resp_data = obj.get_request(route);
+            resp_data = resp_data.observation;
+        end
+        
+        function [resp_data] = env_monitor_start(obj, ...
+                instance_id, directory, varargin)
+            if nargin > 3
+                if nargin == 4
+                    force = varargin{1};
+                    resume = false;
+                else
+                    force = varargin{1};
+                    resume = varargin{2};
+                end
+            else
+                force = false;
+                resume = false;
+            end
+            % Convert true/false to string
+            if force
+               force = 'true';
+            else
+                force = 'false';
+            end
+            if resume
+               resume = 'true';
+            else
+                resume = 'false';
+            end
+            req_data = struct('directory',directory,'force',force,'resume',resume);            
+            route = ['/v1/envs/', instance_id, '/monitor/start/'];  
+            resp_data = obj.post_request(route, req_data);
+        end
+        
+        function [resp_data] = env_monitor_close(obj, instance_id)            
+            route = ['/v1/envs/', instance_id, '/monitor/close/'];  
+            resp_data = obj.post_request(route, []);
+        end
+        
+        function [resp_data] = upload(obj, ...
+                training_dir, varargin)
+            if nargin > 3                
+                if nargin == 4
+                    api_key = varargin{1};
+                    algorithm_id = '';
+                end
+                if nargin == 5
+                    api_key = varargin{1};
+                    algorithm_id = varargin{2};
+                end
+            else
+                api_key = getenv('OPENAI_GYM_API_KEY');
+                algorithm_id = '';
+            end            
+            req_data = struct('training_dir',training_dir,...
+                'algorithm_id',algorithm_id,'api_key',api_key);
+            route = '/v1/upload/';
+            resp_data = obj.post_request(route, req_data);
+        end
+       
+        function shutdown_server(obj)
+            route = '/v1/shutdown/';
+            obj.post_request(route, []);
+        end
+    end    
+end
+


### PR DESCRIPTION
Hi @catherio this is the first version of the matlab client following the structure that we discussed on #239, I tested all the api, functions defined on the example:

``` matlab
%% Example using matlab gym_http_client interface
% Example:
% 1) Server: python gym_http_server.py
% 2) Client: matlab -nojvm -nodisplay -nosplash -r "run example_agent.m"
fprintf('Testing Matlab client\n');

%% Setup client
base = 'http://127.0.0.1:5000';
client = gym_http_client(base);

%% Set up enviroment
env_id = 'CartPole-v0';
instance_id = client.env_create(env_id);

%% Run random experiment with monitor
outdir = 'tmp/random-agent-results';
client.env_monitor_start(instance_id, outdir, true);
render = false;

episode_count = 100;
max_steps = 200;
reward = 0;
done = false;

for i = 1:episode_count
   obs = client.env_reset(instance_id);
   for j=1:max_steps
       action = rand();
       [ob, reward, done, info] = ...
           client.env_step(instance_id, action, render);
       if done
          break; 
       end
   end
end

%% Dump result info to disk
client.env_monitor_close(instance_id);

%% Upload to the scoreboard.
% This expects the 'OPENAI_GYM_API_KEY' enviroment variable to be set on
% the client side.
client.upload(outdir);

%% Close server
%client.shutdown_server();
fprintf('Matlab client test ended\n');
```

Also the push results can be found here:
https://gym.openai.com/evaluations/eval_YHB1wCxSCeaIyH6bfrxdg#reproducibility

