### PR TITLE
MATLAB binding impl missing methods

### DIFF
--- a/binding-matlab/example_agent.m
+++ b/binding-matlab/example_agent.m
@@ -13,7 +13,7 @@ env_id = 'CartPole-v0';
 instance_id = client.env_create(env_id);
 
 %% Run random experiment with monitor
-outdir = 'tmp/random-agent-results';
+outdir = '/tmp/random-matlab-agent-results';
 client.env_monitor_start(instance_id, outdir, true);
 render = false;
 
@@ -25,11 +25,11 @@ done = false;
 for i = 1:episode_count
    obs = client.env_reset(instance_id);
    for j=1:max_steps
-       action = rand();
+       action = client.env_action_space_sample(instance_id);
        [ob, reward, done, info] = ...
            client.env_step(instance_id, action, render);
        if done
-          break; 
+          break;
        end
    end
 end
@@ -42,6 +42,4 @@ client.env_monitor_close(instance_id);
 % the client side.
 client.upload(outdir);
 
-%% Close server
-%client.shutdown_server();
 fprintf('Matlab client test ended\n');

--- a/binding-matlab/gym_http_client.m
+++ b/binding-matlab/gym_http_client.m
@@ -1,77 +1,99 @@
 classdef gym_http_client < handle
-    % Matlab Http client for OpenAI gym    
-    
+    % Matlab Http client for OpenAI gym
+
     properties
-        remote_base        
+        remote_base
     end
-    
-    methods (Access = 'private')
+    properties (SetAccess = private)
+        webopt
+    end
+
+    methods (Access = private)
         % Parse a JSON response, and return a (struct) on resp_data
         % For more information about using JSON in matlab refer to:
         % http://mathworks.com/help/matlab/ref/webread.html
         % http://mathworks.com/help/matlab/ref/webwrite.html
-        function [resp_data] = get_request(obj, route)            
-            resp_data.observation = '';
+        function [resp_data] = get_request(obj, route)
+            url = [obj.remote_base, route];
+            resp_data = webread(url, obj.webopt);
         end
-        
+
         % Encode a JSON message with data described on "req_data", and
         % return a response (struct) on resp_data
-        function [resp_data] = post_request(obj, route, req_data)            
-            url = [obj.remote_base, route];            
-            options = weboptions('MediaType','application/json');
-            resp_data = webwrite(url,req_data,options);
-        end        
+        function [resp_data] = post_request(obj, route, req_data)
+            url = [obj.remote_base, route];
+            resp_data = webwrite(url, req_data, obj.webopt);
+        end
     end
-    
-    methods (Access = 'public')
+
+    methods (Access = public)
         % Constructor
         function [objInstance] = gym_http_client(remote_base)
-            objInstance.remote_base = remote_base;        
+            objInstance.remote_base = remote_base;
+            objInstance.webopt = weboptions( ...
+                'MediaType', 'application/json', ...
+                'Timeout', 10);
         end
-        
+
         function [resp_data] = env_create(obj, env_id)
             route = '/v1/envs/';
             req_data = struct('env_id',env_id);
             resp_data = obj.post_request(route, req_data);
             resp_data = resp_data.instance_id;
         end
-        
+
         function [resp_data] = env_list_all(obj)
             route = '/v1/envs/';
-            resp_data = obj.get_request(obj, route);
+            resp_data = obj.get_request(route);
             resp_data = resp_data.all_envs;
         end
-        
+
         function [resp_data] = env_reset(obj, instance_id)
-            route = ['/v1/envs/', instance_id, '/reset/'];            
+            route = ['/v1/envs/', instance_id, '/reset/'];
             resp_data = obj.post_request(route, []);
             resp_data = resp_data.observation;
         end
-        
+
         function [obs, reward, done, info] = env_step(obj, ...
-                instance_id, action, render)            
+                instance_id, action, render)
+            if ~exist('render', 'var')
+                render = false;
+            end
             route = ['/v1/envs/', instance_id, '/step/'];
-            req_data = struct('action',action,'render',render);
+            req_data = struct('action', action, 'render', render);
             resp_data = obj.post_request(route, req_data);
             obs = resp_data.observation;
             reward = resp_data.reward;
             done = resp_data.done;
             info = resp_data.info;
         end
-        
+
         function [resp_data] = env_action_space_info(obj, instance_id)
-            route = ['/v1/envs/', instance_id, '/action_space/'];            
+            route = ['/v1/envs/', instance_id, '/action_space/'];
             resp_data = obj.get_request(route);
-            resp_data = resp_data.observation;
+            resp_data = resp_data.info;
         end
-        
+
+        function [resp_data] = env_action_space_sample(obj, instance_id)
+            route = ['/v1/envs/', instance_id, '/action_space/sample'];
+            resp_data = obj.get_request(route);
+            resp_data = resp_data.action;
+        end
+
+        function [resp_data] = env_action_space_contains(obj, instance_id, x)
+            route = ['/v1/envs/', instance_id, ...
+                     '/action_space/contains/', num2str(x)];
+            resp_data = obj.get_request(route);
+            resp_data = resp_data.member;
+        end
+
         function [resp_data] = env_observation_space_info(obj, instance_id)
-            route = ['/v1/envs/', instance_id, '/observation_space/'];            
+            route = ['/v1/envs/', instance_id, '/observation_space/'];
             resp_data = obj.get_request(route);
-            resp_data = resp_data.observation;
+            resp_data = resp_data.info;
         end
-        
-        function [resp_data] = env_monitor_start(obj, ...
+
+        function env_monitor_start(obj, ...
                 instance_id, directory, varargin)
             if nargin > 3
                 if nargin == 4
@@ -85,30 +107,22 @@ classdef gym_http_client < handle
                 force = false;
                 resume = false;
             end
-            % Convert true/false to string
-            if force
-               force = 'true';
-            else
-                force = 'false';
-            end
-            if resume
-               resume = 'true';
-            else
-                resume = 'false';
-            end
-            req_data = struct('directory',directory,'force',force,'resume',resume);            
-            route = ['/v1/envs/', instance_id, '/monitor/start/'];  
-            resp_data = obj.post_request(route, req_data);
+            req_data = struct( ...
+                'directory', directory, ...
+                'force', force, ...
+                'resume', resume);
+            route = ['/v1/envs/', instance_id, '/monitor/start/'];
+            obj.post_request(route, req_data);
         end
-        
-        function [resp_data] = env_monitor_close(obj, instance_id)            
-            route = ['/v1/envs/', instance_id, '/monitor/close/'];  
-            resp_data = obj.post_request(route, []);
+
+        function env_monitor_close(obj, instance_id)
+            route = ['/v1/envs/', instance_id, '/monitor/close/'];
+            obj.post_request(route, []);
         end
-        
-        function [resp_data] = upload(obj, ...
+
+        function upload(obj, ...
                 training_dir, varargin)
-            if nargin > 3                
+            if nargin > 3
                 if nargin == 4
                     api_key = varargin{1};
                     algorithm_id = '';
@@ -120,17 +134,17 @@ classdef gym_http_client < handle
             else
                 api_key = getenv('OPENAI_GYM_API_KEY');
                 algorithm_id = '';
-            end            
+            end
             req_data = struct('training_dir',training_dir,...
                 'algorithm_id',algorithm_id,'api_key',api_key);
             route = '/v1/upload/';
-            resp_data = obj.post_request(route, req_data);
+            obj.post_request(route, req_data);
         end
-       
+
         function shutdown_server(obj)
             route = '/v1/shutdown/';
             obj.post_request(route, []);
         end
-    end    
+    end
 end
 


### PR DESCRIPTION
In the MATLAB binding, implement a few methods that were missing or broken: `env_list_all`, `env_action_space_info`, `env_action_space_sample`, `env_observation_space_info`.