### PR TITLE
fix: monitor wrapper

### DIFF
--- a/gym_http_server.py
+++ b/gym_http_server.py
@@ -2,6 +2,7 @@ from flask import Flask, request, jsonify
 from functools import wraps
 import uuid
 import gym
+from gym import wrappers
 import numpy as np
 import six
 import argparse
@@ -121,11 +122,12 @@ class Envs(object):
             v_c = lambda count: False
         else:
             v_c = lambda count: count % video_callable == 0
-        env.monitor.start(directory, force=force, resume=resume, video_callable=v_c)
+        #env.monitor.start(directory, force=force, resume=resume, video_callable=v_c)
+        self.envs[instance_id] = wrappers.Monitor(env, directory, force=force, resume=resume, video_callable=v_c) 
 
     def monitor_close(self, instance_id):
         env = self._lookup_env(instance_id)
-        env.monitor.close()
+        env.close()
 
     def env_close(self, instance_id):
         env = self._lookup_env(instance_id)


### PR DESCRIPTION
If I try to record results, the following error is raised

>raise error.Error("env.monitor has been deprecated as of 12/23/2016. Remove your call to `env.monitor.start(directory)` and instead wrap your env with `env = gym.wrappers.Monitor(env, directory)` to record data.")


The correct way to use monitors: 

Open Monitor
```python
from gym import wrappers
env = gym.make('CartPole-v0')
env = wrappers.Monitor(env, LOG_DIR)
```

Close Monitor
```python
env.close()
```