### PR TITLE
update gym version to 0.7.4

### DIFF
--- a/gym_http_server.py
+++ b/gym_http_server.py
@@ -122,7 +122,6 @@ class Envs(object):
             v_c = lambda count: False
         else:
             v_c = lambda count: count % video_callable == 0
-        #env.monitor.start(directory, force=force, resume=resume, video_callable=v_c)
         self.envs[instance_id] = wrappers.Monitor(env, directory, force=force, resume=resume, video_callable=v_c) 
 
     def monitor_close(self, instance_id):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Flask==0.11.1
 numpy==1.11.1rc1
-gym==0.1.7
+gym==0.7.4
 requests==2.11.0
 nose2==0.6.5


### PR DESCRIPTION
Closes #37. I figure this is a safe number to update to since the [next breaking changes scheduled for the gym are to be released in 0.8.0](https://github.com/openai/gym#what-s-new), even if the changes are in master and 0.7.4 was tagged two days ago. Removal of the configure method doesn't seem to affect this repo.