### PR TITLE
set environment for execution in shell

### DIFF
--- a/gym_http_server.py
+++ b/gym_http_server.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 from flask import Flask, request, jsonify
 from functools import wraps
 import uuid


### PR DESCRIPTION
For this to work, it would require deleting and checking in a new executable `gym_http_server.py` -- which I'm peevish to do because it would mess with the git history. I think this should be enough since running the server as a CLI tool would still require fiddling with system environments (adding the repo to PATH, etc).

This has no impact on the usual `python gym_http_server`, is tested on zsh and bash, and seems to be pyenv-virtualenv friendly.