### PR TITLE
don't prettify JSON

### DIFF
--- a/gym_http_server.py
+++ b/gym_http_server.py
@@ -136,6 +136,7 @@ class Envs(object):
 
 ########## App setup ##########
 app = Flask(__name__)
+app.config['JSONIFY_PRETTYPRINT_REGULAR'] = False
 envs = Envs()
 
 ########## Error handling ##########


### PR DESCRIPTION
jsonify() runs significantly faster when it does not have to prettify, especially in Python 3.6. This is important for environments like Pong-v0, where jsonify() can be a significant bottleneck.

Here are some performance comparisons when I capture 6 frames from Pong-v0:

|Python Version|Pretty|Not pretty|
|--------------|------|----------|
|Python 3.6    |2.8s  |**1.3s**  |
|Python 2.7    |3.6s  |2.8s      |

Reference:
http://stackoverflow.com/questions/37931927/why-is-flasks-jsonify-method-slow