### PR TITLE
Fix lgtm.com alerts: Clean up some unnecessary imports.

### DIFF
--- a/example_agent.py
+++ b/example_agent.py
@@ -1,6 +1,4 @@
 import logging
-import os, sys
-import numpy as np
 
 from gym_http_client import Client
 

--- a/gym_http_server.py
+++ b/gym_http_server.py
@@ -1,13 +1,10 @@
 #!/usr/bin/env python3
 from flask import Flask, request, jsonify
-from functools import wraps
 import uuid
 import gym
-from gym import wrappers
 import numpy as np
 import six
 import argparse
-import sys
 
 import logging
 logger = logging.getLogger('werkzeug')
@@ -123,7 +120,7 @@ class Envs(object):
             v_c = lambda count: False
         else:
             v_c = lambda count: count % video_callable == 0
-        self.envs[instance_id] = wrappers.Monitor(env, directory, force=force, resume=resume, video_callable=v_c) 
+        self.envs[instance_id] = gym.wrappers.Monitor(env, directory, force=force, resume=resume, video_callable=v_c) 
 
     def monitor_close(self, instance_id):
         env = self._lookup_env(instance_id)


### PR DESCRIPTION
This PR fixes some of the import-related alerts found at https://lgtm.com/projects/g/openai/gym-http-api/alerts. This should make clear what modules are used in the `example_agent` and `http_server`.