### PR TITLE
binding-rust: remove openssl dependencies

### DIFF
--- a/binding-rust/Cargo.toml
+++ b/binding-rust/Cargo.toml
@@ -6,4 +6,4 @@ authors = ["NivenT <nachenjang@gmail.com>"]
 [dependencies]
 rand = "0.3.14"
 serde_json = "0.8.0"
-hyper = "0.9.12"
+hyper = {version = "0.9.12", default-features = false}


### PR DESCRIPTION
hyper 0.9.x depends of openssl by default, and it can failed to compile if openssl dev lib is not installed. As ssl is not used by gym-http server, then remove openssl as transitive dependency.